### PR TITLE
Adding array notation for proper minification

### DIFF
--- a/src/angular-wysiwyg.js
+++ b/src/angular-wysiwyg.js
@@ -44,7 +44,7 @@ Requires:
     ];
 
     angular.module('wysiwyg.module', ['colorpicker.module'])
-        .directive('wysiwyg', function($timeout, wysiwgGui, $compile) {
+        .directive('wysiwyg', ['$timeout', 'wysiwgGui', '$compile', function($timeout, wysiwgGui, $compile) {
             return {
                 template: '<div>' +
                     '<style>' +
@@ -298,7 +298,7 @@ Requires:
                 scope.format('enableobjectresizing', true);
                 scope.format('styleWithCSS', true);
             };
-        })
+        }])
         .factory('wysiwgGui', function(wysiwgGuiElements) {
 
             var ELEMENTS = wysiwgGuiElements;


### PR DESCRIPTION
I ran into an issue where we installed angular-wysiwyg using bower, but our grunt compile task (taken from Josh Miller's [ngbp](https://github.com/ngbp/ngbp)) was not minifying this file, meaning that the uglify was breaking our app. We didn't want to run ng-Annotate on all of our vendor files because that takes a lot of time when it's not normally needed, so I figured adding the array notation to this project would be the simplest solution and hopefully save others the same headache.