### PR TITLE
Fix Safari 'undefined'

### DIFF
--- a/src/angular-wysiwyg.js
+++ b/src/angular-wysiwyg.js
@@ -435,7 +435,7 @@ Requires:
 
                 if (obj.text && document.all) {
                     el.innerText = obj.text;
-                } else {
+                } else if (obj.text) {
                     el.textContent = obj.text;
                 }
 


### PR DESCRIPTION
typeof obj.text == 'undefined' displays 'undefined' text on Safari