### PR TITLE
Prevent unexpected behavior of disabled when there is more than 1 component

### DIFF
--- a/src/angular-wysiwyg.js
+++ b/src/angular-wysiwyg.js
@@ -173,10 +173,10 @@ Requires:
 
                 function configureDisabledWatch() {
                     scope.$watch('disabled', function(newValue) {
-                        angular.element('div.wysiwyg-menu').find('button').each(function() {
+                        element.children('div.wysiwyg-menu').find('button').each(function() {
                             angular.element(this).attr('disabled', newValue);
                         });
-                        angular.element('div.wysiwyg-menu').find('select').each(function() {
+                        element.children('div.wysiwyg-menu').find('select').each(function() {
                             angular.element(this).attr('disabled', newValue);
                         });
                     });


### PR DESCRIPTION
There was a bug when a page contains more than 1 wysiwyg component with the property disabled.

The previous implementation was Enabling/Disabling every menus in the page each times the value the property was changing.

This fix selects only the menu concerned.